### PR TITLE
Improve efficiency with cached loading and table helper

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,14 +1,8 @@
 # Reporting_Dashboard-Copy1.ipynb
-import re
 import pandas as pd
-import plotly.express as px
-import plotly.graph_objects as go
 from pathlib import Path
-from datetime import date
-from datetime import timedelta
-import math
 import os
-from dash import Dash, dcc, html, dash_table
+from dash import Dash, dcc, html
 from dash.dependencies import Input, Output
 from data_fetcher import *
 from dashboard_utils import *

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -7,42 +7,23 @@ import re
 
 from io import StringIO
 from pathlib import Path
-from typing import Optional, Tuple
 from urllib.parse import quote_plus
 
 
 # ─── 0. Cookie Loader ─────────────────────────────────────────────────────────
+def get_session_with_canvas_cookie(cookie_path=None):
+    """Return a ``requests.Session`` populated with Canvas cookies."""
+    if cookie_path is None:
+        cookie_path = os.environ.get("COOKIE_PATH", "canvas_cookies.json")
 
-# For RENDER!
-def get_session_with_canvas_cookie(cookie_path="/etc/secrets/canvas_cookies.json"):
-    import json
-    session = requests.Session()
     with open(cookie_path, "r") as f:
-        cookies = json.load(f)
-    for cookie in cookies:
-        session.cookies.set(cookie['name'], cookie['value'])
-    return session
-
-# For Testing!
-
-# COOKIE_PATH = "canvas_cookies.json"
-
-
-def get_session_with_canvas_cookie():
-    """
-    Load cookies from COOKIE_PATH and return a requests.Session
-    that only sets name, value, domain, path, secure, and expires.
-    """
-    with open(COOKIE_PATH, "r") as f:
         raw_cookies = json.load(f)
 
     session = requests.Session()
     for c in raw_cookies:
-        # required:
         name = c.get("name")
         value = c.get("value")
 
-        # optional but valid in requests:
         params = {}
         if "domain" in c:
             params["domain"] = c["domain"]
@@ -51,7 +32,6 @@ def get_session_with_canvas_cookie():
         if "secure" in c:
             params["secure"] = c["secure"]
         if "expirationDate" in c:
-            # requests wants 'expires' (an int)
             params["expires"] = int(c["expirationDate"])
 
         session.cookies.set(name, value, **params)


### PR DESCRIPTION
## Summary
- read Canvas cookies from `COOKIE_PATH` env var with single helper
- cache parquet loading with `lru_cache`
- centralize call center table styling in a helper
- remove unused imports across modules

## Testing
- `python -m py_compile data_fetcher.py dashboard_utils.py app.py`

------
https://chatgpt.com/codex/tasks/task_b_685992db54508323abce541ce04c908b